### PR TITLE
Remove trailing comma in JSON

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     {
       "name": "Nick Kravchuk",
       "email": "nick@hexbrain.com",
-      "homepage": "http://www.hexbrain.com/",
+      "homepage": "http://www.hexbrain.com/"
     }
   ],
   "autoload": {


### PR DESCRIPTION
Throws a JSON formatter error when installing via Composer.